### PR TITLE
Enable ponytail plugin

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "enabledPlugins": {
+    "ponytail@ponytail": true
+  }
+}


### PR DESCRIPTION
Включает плагин `ponytail` в настройках проекта (`.claude/settings.json`).

Плагин ставится из маркетплейса `DietrichGebert/ponytail`, который добавляется локально (`~/.claude`), поэтому у тех, кто маркетплейс не добавлял, флаг просто ни на что не влияет.

🤖 Generated with [Claude Code](https://claude.com/claude-code)