### PR TITLE
Add Allure TestOps MCP server

### DIFF
--- a/.ai/rules/general.md
+++ b/.ai/rules/general.md
@@ -1,0 +1,11 @@
+---
+paths:
+  - .mcp.json
+---
+
+# General
+
+## claude mcp list не проверяет авторизацию HTTP-серверов
+Для `allure-testops` (HTTP MCP, токен подставляется из `${ALLURE_TESTOPS_TOKEN}`) `claude mcp list` печатает `✔ Connected` даже когда переменная не задана и заголовок уходит нерасширённым. Статус в списке — это не сигнал об успешной аутентификации.
+
+Проверять подключение только вызовом инструмента, например `testops_get_project` (в дочерней сессии: `claude -p --permission-mode default ... --allowedTools "mcp__allure-testops__testops_get_project"`). `claude mcp get` тоже бесполезен: он показывает конфиг до подстановки.

--- a/.ai/rules/index.md
+++ b/.ai/rules/index.md
@@ -1,0 +1,7 @@
+# Project Rules Index
+
+Before planning or editing, find the row whose globs match the file's path and read that rule file.
+
+| Applies to | Rule file |
+| --- | --- |
+| .mcp.json | .ai/rules/general.md |

--- a/.mcp.json
+++ b/.mcp.json
@@ -6,6 +6,13 @@
                 "artisan",
                 "boost:mcp"
             ]
+        },
+        "allure-testops": {
+            "type": "http",
+            "url": "https://hexlet.testops.cloud/api/mcp",
+            "headers": {
+                "Authorization": "api-token ${ALLURE_TESTOPS_TOKEN}"
+            }
         }
     }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,18 @@ Hexlet SICP — трекер изучения книги SICP: пользова�
 - Testsuite четыре — `Unit`, `Feature`, `Exercises`, `Sandbox`; по умолчанию запускается `Feature`.
 - Racket (`raco`) нужен для `Exercises` и для `CheckControllerTest` в `Feature`. Локально его может не быть — тогда падают именно они, и это не регрессия: свои изменения проверять по остальным тестам.
 
+## MCP
+
+`.mcp.json` описывает два сервера: `laravel-boost` (`php artisan boost:mcp`) и `allure-testops` (HTTP, `https://hexlet.testops.cloud/api/mcp` — тест-кейсы, тест-результаты по AQL, mute'ы).
+
+Токен Allure в git не лежит: заголовок собирается из `${ALLURE_TESTOPS_TOKEN}`. Чтобы сервер заработал у себя:
+
+1. Создать личный токен в TestOps: аватар → *Profile* → *API tokens*.
+2. Положить его в `env.ALLURE_TESTOPS_TOKEN` в `.claude/settings.local.json` (файл вне git) или в переменную окружения.
+3. Разрешить сервер при первом запуске — либо добавить `allure-testops` в `enabledMcpjsonServers` там же.
+
+Переменная не задана — конфиг всё равно загрузится, `${ALLURE_TESTOPS_TOKEN}` уйдёт в заголовок как есть, и сервер молча не будет работать. **`claude mcp list` это не поймает: он печатает `✔ Connected` и без токена.** Проверять вызовом инструмента, например `testops_get_project`.
+
 ## Architecture
 
 ### Домен (app/Models)


### PR DESCRIPTION
Подключает `hexlet.testops.cloud` как HTTP MCP-сервер в `.mcp.json` — рядом с уже настроенным `laravel-boost`. Агенты получают доступ к тест-кейсам, тест-результатам (поиск по AQL), mute'ам и shared steps.

## Токен не в репозитории

Заголовок собирается из `${ALLURE_TESTOPS_TOKEN}` — подстановка переменных в `headers` поддерживается Claude Code официально. Значение каждый держит у себя: `env.ALLURE_TESTOPS_TOKEN` в `.claude/settings.local.json` (файл вне git) либо переменная окружения. Инструкция — в новом разделе `## MCP` в `AGENTS.md`.

## Ловушка, которую стоит знать

Если переменная не задана, конфиг всё равно загружается, `${ALLURE_TESTOPS_TOKEN}` уходит в заголовок дословно, и сервер молча не работает. **`claude mcp list` этого не показывает — печатает `✔ Connected` и без токена** (проверено: убирал переменную, статус не менялся). Единственная надёжная проверка — вызов инструмента; записано в `.ai/rules/general.md`.

Подключение проверено end-to-end: `testops_get_project` вернул реальные данные проекта.

🤖 Generated with [Claude Code](https://claude.com/claude-code)