### PR TITLE
Drop unused deps and align stack versions

### DIFF
--- a/.ai/rules/general.md
+++ b/.ai/rules/general.md
@@ -1,0 +1,11 @@
+---
+paths:
+  - .mcp.json
+---
+
+# General
+
+## claude mcp list не проверяет авторизацию HTTP-серверов
+Для `allure-testops` (HTTP MCP, токен подставляется из `${ALLURE_TESTOPS_TOKEN}`) `claude mcp list` печатает `✔ Connected` даже когда переменная не задана и заголовок уходит нерасширённым. Статус в списке — это не сигнал об успешной аутентификации.
+
+Проверять подключение только вызовом инструмента, например `testops_get_project` (в дочерней сессии: `claude -p --permission-mode default ... --allowedTools "mcp__allure-testops__testops_get_project"`). `claude mcp get` тоже бесполезен: он показывает конфиг до подстановки.

--- a/.ai/rules/index.md
+++ b/.ai/rules/index.md
@@ -1,0 +1,7 @@
+# Project Rules Index
+
+Before planning or editing, find the row whose globs match the file's path and read that rule file.
+
+| Applies to | Rule file |
+| --- | --- |
+| .mcp.json | .ai/rules/general.md |

--- a/.mcp.json
+++ b/.mcp.json
@@ -6,6 +6,13 @@
                 "artisan",
                 "boost:mcp"
             ]
+        },
+        "allure-testops": {
+            "type": "http",
+            "url": "https://hexlet.testops.cloud/api/mcp",
+            "headers": {
+                "Authorization": "api-token ${ALLURE_TESTOPS_TOKEN}"
+            }
         }
     }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,18 @@ Hexlet SICP — трекер изучения книги SICP: пользова�
 - Testsuite четыре — `Unit`, `Feature`, `Exercises`, `Sandbox`; по умолчанию запускается `Feature`.
 - Racket (`raco`) нужен для `Exercises` и для `CheckControllerTest` в `Feature`. Локально его может не быть — тогда падают именно они, и это не регрессия: свои изменения проверять по остальным тестам.
 
+## MCP
+
+`.mcp.json` описывает два сервера: `laravel-boost` (`php artisan boost:mcp`) и `allure-testops` (HTTP, `https://hexlet.testops.cloud/api/mcp` — тест-кейсы, тест-результаты по AQL, mute'ы).
+
+Токен Allure в git не лежит: заголовок собирается из `${ALLURE_TESTOPS_TOKEN}`. Чтобы сервер заработал у себя:
+
+1. Создать личный токен в TestOps: аватар → *Profile* → *API tokens*.
+2. Положить его в `env.ALLURE_TESTOPS_TOKEN` в `.claude/settings.local.json` (файл вне git) или в переменную окружения.
+3. Разрешить сервер при первом запуске — либо добавить `allure-testops` в `enabledMcpjsonServers` там же.
+
+Переменная не задана — конфиг всё равно загрузится, `${ALLURE_TESTOPS_TOKEN}` уйдёт в заголовок как есть, и сервер молча не будет работать. **`claude mcp list` это не поймает: он печатает `✔ Connected` и без токена.** Проверять вызовом инструмента, например `testops_get_project`.
+
 ## Architecture
 
 ### Домен (app/Models)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,25 @@
 
 Hexlet SICP — трекер изучения книги SICP: пользователи читают главы (иерархическое дерево), решают упражнения на Scheme/Racket, набирают баллы и попадают в лидерборды. БД — PostgreSQL везде: локально, в тестах и в проде. Фронтенд — **hybrid**: часть страниц на Blade, часть уже на Inertia + React.
 
+## Stack (версии)
+
+**Источник истины — Docker.** Манифесты задают минимальную версию, и этот минимум держим равным образу: разошлось — подтягиваем манифест к образу, а не наоборот.
+
+| | Версия | Где задана |
+| --- | --- | --- |
+| PHP | 8.5 | `Dockerfile.dev`: `PHP_VERSION=8.5`; минимум `^8.5` в `composer.json` |
+| Node | 24 | `Dockerfile.dev`: `NODE_MAJOR=24`; минимум `>=24.x` в `package.json` `engines` |
+| PostgreSQL | 18 | `postgres:18-alpine` в `docker-compose.yml`, `.ci.yml` и `.stage.yml` |
+| Racket | не пинится | из apt базового `ubuntu:26.04` |
+
+Ключевые пакеты: Laravel 13, PHPUnit 13, larastan 3, `inertiajs/inertia-laravel` **v3** + `@inertiajs/react` v3, React 19, Vite 8, Biome 2, spatie/laravel-data 4.
+
+- `Dockerfile` (прод) и `Dockerfile.stage` начинаются с `INCLUDE+ Dockerfile.dev` (dockerfile-plus), поэтому версии PHP и Node задаются в одном месте — править `Dockerfile.dev`.
+- CI своих версий не задаёт: `pull_request.yml` просто гоняет `make ci` внутри того же образа `Dockerfile.dev`.
+- Подняв `php` в `composer.json`, обязательно прогнать `composer update --lock`: платформенные требования composer сверяет по `platform` в `composer.lock`, а не по `composer.json` (был #121). Команда меняет только `content-hash` и `platform`, версии пакетов не двигает.
+- Racket — единственная незакреплённая зависимость, и именно она гейтит testsuite `Exercises` и `CheckControllerTest`. Апгрейд базового образа может сломать их без изменений в коде.
+- `app.json` (деплой по кнопке в Heroku) живёт своей жизнью и отстал: `stack: heroku-20`, Postgres 13, `RACKET_VERSION: 7.9`. Docker-стек на него не влияет — сверяться с ним нельзя.
+
 ## Where to look
 
 - **Issue, триаж, метки** → `docs/agents/issue-tracker.md`. Трекер — upstream `hexlet-volunteers/hexlet-sicp` (не форк), работа через `gh` CLI, issue пишутся по-русски; пять канонических триаж-меток разобраны в `docs/agents/triage-labels.md`.
@@ -22,6 +41,8 @@ Hexlet SICP — трекер изучения книги SICP: пользова�
 - `make analyse` — заглушка (`@echo 'fixme'`, вызов phpstan закомментирован). Поэтому pre-push-хук и CI фактически гоняют только lint и тесты.
 - Testsuite четыре — `Unit`, `Feature`, `Exercises`, `Sandbox`; по умолчанию запускается `Feature`.
 - Racket (`raco`) нужен для `Exercises` и для `CheckControllerTest` в `Feature`. Локально его может не быть — тогда падают именно они, и это не регрессия: свои изменения проверять по остальным тестам.
+- `make start` (без Docker) поднимает приложение через **Heroku CLI** — `heroku local -f Procfile.dev`, а не `artisan serve`. Без установленного `heroku` работает только `make start-app` / `make start-frontend` или compose-цели.
+- **`php artisan route:list` в этом проекте не работает вообще:** mcamara/laravel-localization перебивает биндинг команды своим `RouteTranslationsListCommand`, а тот в `handle()` читает необъявленный аргумент `locale` → `The "locale" argument does not exist`. Флаги не помогают, `route:trans:list` не зарегистрирован. Маршруты смотреть прямо в `routes/web.php` и `routes/api.php`.
 
 ## MCP
 
@@ -58,7 +79,7 @@ Hexlet SICP — трекер изучения книги SICP: пользова�
 
 ### Фронтенд (hybrid Blade + Inertia/React)
 
-Приложение переезжает на Inertia + Mantine постранично (**strangler**, ADR 0001), поэтому Blade и Inertia сосуществуют — и все правила ниже следуют из этого.
+Приложение переезжает на Inertia + Mantine постранично (**strangler**, ADR 0001), поэтому Blade и Inertia сосуществуют — и все правила ниже следуют из этого. **Mantine — цель, а не текущее состояние:** в `package.json` его пока нет, единственная Inertia-страница собрана на `react-bootstrap`. Упоминания Mantine ниже читать как «когда он появится».
 
 Устройство:
 
@@ -112,25 +133,11 @@ The Laravel Boost guidelines are specifically curated by Laravel maintainers for
 
 ## Foundational Context
 
-This application is a Laravel application and its main Laravel ecosystems package & versions are below. You are an expert with them all. Ensure you abide by these specific packages & versions.
+This application is a Laravel application running on PHP 8.5. You are an expert with the Laravel ecosystem. Always use the APIs that match the installed major version of each package — do not assume a version.
 
-- php - 8.4
-- inertiajs/inertia-laravel (INERTIA_LARAVEL) - v2
-- laravel/framework (LARAVEL) - v13
-- laravel/prompts (PROMPTS) - v0
-- laravel/socialite (SOCIALITE) - v5
-- larastan/larastan (LARASTAN) - v3
-- laravel/boost (BOOST) - v2
-- laravel/mcp (MCP) - v0
-- phpunit/phpunit (PHPUNIT) - v12
-- @inertiajs/react (INERTIA_REACT) - v3
-- react (REACT) - v19
-- eslint (ESLINT) - v10
-- prettier (PRETTIER) - v3
-
-## Skills Activation
-
-This project has domain-specific skills available in `**/skills/**`. You MUST activate the relevant skill whenever you work in that domain—don't wait until you're stuck.
+Before relying on a package's API, confirm its installed version:
+- PHP packages: run `composer show --direct` to list direct dependencies with versions, or `composer show <vendor/package>` for a single package.
+- JS packages: check `package.json` for the installed versions.
 
 ## Conventions
 
@@ -185,6 +192,11 @@ This project has domain-specific skills available in `**/skills/**`. You MUST ac
 3. Combine words and phrases for mixed queries: `middleware "rate limit"`.
 4. Use multiple queries for OR logic: `queries=["authentication", "middleware"]`.
 
+## Project Rules
+
+- This project contains committed, area-grouped rules in `.ai/rules` when that directory exists (settled decisions, non-obvious traps, standing constraints). Framework and package guidelines that only apply to specific paths (testing, frontend, components) also live there, under `.ai/rules/boost` — this is not just recorded decisions, it is load-bearing guidance you have not seen inline. Before you enter plan mode or create/edit any file, you MUST first: open @.ai/rules/index.md (it maps file globs to rule files), read every rule file whose globs cover the path(s) in scope, and run `grep -rin 'keyword' .ai/rules` to catch what a path match alone misses. Do not write code until you have read and are following every matching rule. If `.ai/rules` does not exist, continue without it.
+- Record durable rules with `record-rule` so the next agent or teammate inherits them instead of working them out again. Pass a `glob` (e.g. `app/Http/Controllers/**`), a short `title`, and a few-line `note`. Always use `record-rule`, never your native memory or notes tool — native memory is personal and session-scoped; only `.ai/rules` is shared with the team and persists in the repo.
+
 ## Artisan
 
 - Run Artisan commands directly via the command line (e.g., `php artisan route:list`). Use `php artisan list` to discover available commands and `php artisan [command] --help` to check parameters.
@@ -230,11 +242,19 @@ This project has domain-specific skills available in `**/skills/**`. You MUST ac
 - ALWAYS use `search-docs` tool for version-specific Inertia documentation and updated code examples.
 - IMPORTANT: Activate `inertia-react-development` when working with Inertia client-side patterns.
 
-# Inertia v2
+# Inertia v3
 
-- Use all Inertia features from v1 and v2. Check the documentation before making changes to ensure the correct approach.
-- New features: deferred props, infinite scroll, merging props, polling, prefetching, once props, flash data.
+- Use all Inertia features from v1, v2, and v3. Check the documentation before making changes to ensure the correct approach.
+- New v3 features: standalone HTTP requests (`useHttp` hook), optimistic updates with automatic rollback, layout props (`useLayoutProps` hook), instant visits, simplified SSR via `@inertiajs/vite` plugin, custom exception handling for error pages.
+- Carried over from v2: deferred props, infinite scroll, merging props, polling, prefetching, once props, flash data.
 - When using deferred props, add an empty state with a pulsing or animated skeleton.
+- Axios has been removed. Use the built-in XHR client with interceptors, or install Axios separately if needed.
+- `Inertia::lazy()` / `LazyProp` has been removed. Use `Inertia::optional()` instead.
+- Prop types (`Inertia::optional()`, `Inertia::defer()`, `Inertia::merge()`) work inside nested arrays with dot-notation paths.
+- SSR works automatically in Vite dev mode with `@inertiajs/vite` - no separate Node.js server needed during development.
+- Event renames: `invalid` is now `httpException`, `exception` is now `networkError`.
+- `router.cancel()` replaced by `router.cancelAll()`.
+- The `future` configuration namespace has been removed - all v2 future options are now always enabled.
 
 === laravel/core rules ===
 
@@ -289,79 +309,5 @@ This project has domain-specific skills available in `**/skills/**`. You MUST ac
 # Inertia + React
 
 - IMPORTANT: Activate `inertia-react-development` when working with Inertia React client-side patterns.
-
-=== barryvdh/laravel-debugbar rules ===
-
-## Laravel Debugbar
-
-Laravel Debugbar stores data from each request (queries, exceptions, views, routes, mail, etc.) for review via Artisan commands.
-
-### Finding Requests
-
-<code-snippet name="Find requests" lang="bash">
-
-# List recent requests (shows summary with status, duration, memory, query count)
-
-php artisan debugbar:find
-
-# Filter by URI pattern (fnmatch) and/or HTTP method
-
-php artisan debugbar:find --uri="/api/*" --method=POST
-
-# Only show requests with issues (exceptions, slow queries, duplicates, errors)
-
-php artisan debugbar:find --issues --max=50
-
-# Customize issue thresholds (defaults: --min-queries=50, --min-duration=1000, --min-duplicates=2)
-
-php artisan debugbar:find --issues --min-queries=10 --min-duration=500
-
-# Threshold options also work standalone, filtering on just that criteria
-
-php artisan debugbar:find --min-queries=20
-</code-snippet>
-
-`--issues` flags: exceptions, non-2xx status, high query count, slow queries, duplicate query groups, slow request duration, and failed queries. Issue filtering applies on top of the fetched result set — increase `--max` to scan further back.
-
-### Inspecting a Request
-
-<code-snippet name="Inspect request" lang="bash">
-
-# Summary of all collectors (available collectors depend on config)
-
-php artisan debugbar:get latest
-php artisan debugbar:get {id}
-
-# Full data for a specific collector
-
-php artisan debugbar:get {id} --collector=exceptions
-</code-snippet>
-
-Use the collector name from the summary table. Common ones by issue type:
-- **Error/500** → `exceptions` · **Slow page** → `queries`, `time` · **Auth** → `auth`, `gate` · **Cache** → `cache`
-
-### Analyzing Queries
-
-<code-snippet name="Query analysis" lang="bash">
-
-# Overview with duplicate detection and slow query flags
-
-php artisan debugbar:queries {id}
-
-# Backtrace and params for a specific statement
-
-php artisan debugbar:queries {id} --statement=N
-
-# EXPLAIN plan or re-execute a SELECT
-
-php artisan debugbar:queries {id} --statement=N --explain
-php artisan debugbar:queries {id} --statement=N --result
-</code-snippet>
-
-Duplicate queries are a strong N+1 signal. Use `--statement=N` to get the backtrace and find the origin.
-
-### Other Commands
-
-- `debugbar:clear` — Clear all stored debugbar data.
 
 </laravel-boost-guidelines>

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-# NOTE: PHP 8.4 comes from packages.sury.org, which lags behind new Ubuntu releases.
+# NOTE: PHP 8.5 comes from packages.sury.org, which lags behind new Ubuntu releases.
 # Before bumping this tag, check the codename in https://packages.sury.org/php/dists/
 FROM ubuntu:26.04
 

--- a/app/Presenters/CommentPresenter.php
+++ b/app/Presenters/CommentPresenter.php
@@ -3,6 +3,7 @@
 namespace App\Presenters;
 
 use Hemp\Presenter\Presenter;
+use Illuminate\Support\Str;
 
 /**
  * @mixin \App\Models\Comment
@@ -11,7 +12,7 @@ class CommentPresenter extends Presenter
 {
     public function getLink(): string
     {
-        $commentableResourceName = str_plural(strtolower(class_basename($this->commentable_type)));
+        $commentableResourceName = Str::plural(strtolower(class_basename($this->commentable_type)));
         $commentableUrl = route("{$commentableResourceName}.show", $this->commentable);
         $commentUrl = "{$commentableUrl}#comment-{$this->id}";
         return $commentUrl;

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "license": "MIT",
     "require": {
-        "php": "^8.3.0",
+        "php": "^8.5",
         "ext-bcmath": "*",
         "ext-curl": "*",
         "ext-dom": "*",
@@ -34,8 +34,6 @@
         "knplabs/github-api": "^3.16",
         "laracasts/flash": "^3.2",
         "laravel/framework": "^13",
-        "laravel/helpers": "^1.7",
-        "laravel/legacy-factories": "^1.3",
         "laravel/socialite": "^5.11",
         "laravel/tinker": "^3.0",
         "laravel/ui": "^v4.2.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0bd28e2d543fcce7a6fca19b22d24245",
+    "content-hash": "f5f1ea8a6d9199420ab3daac12adfd52",
     "packages": [
         {
             "name": "brick/math",
@@ -2240,119 +2240,6 @@
                 "source": "https://github.com/laravel/framework"
             },
             "time": "2026-08-11T13:56:22+00:00"
-        },
-        {
-            "name": "laravel/helpers",
-            "version": "v1.8.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laravel/helpers.git",
-                "reference": "5915be977c7cc05fe2498d561b8c026ee56567dd"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laravel/helpers/zipball/5915be977c7cc05fe2498d561b8c026ee56567dd",
-                "reference": "5915be977c7cc05fe2498d561b8c026ee56567dd",
-                "shasum": ""
-            },
-            "require": {
-                "illuminate/support": "~5.8.0|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
-                "php": "^7.2.0|^8.0"
-            },
-            "require-dev": {
-                "phpstan/phpstan": "^1.10",
-                "phpunit/phpunit": "^7.0|^8.0|^9.0|^10.0|^11.0|^12.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "src/helpers.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Taylor Otwell",
-                    "email": "taylor@laravel.com"
-                },
-                {
-                    "name": "Dries Vints",
-                    "email": "dries@laravel.com"
-                }
-            ],
-            "description": "Provides backwards compatibility for helpers in the latest Laravel release.",
-            "keywords": [
-                "helpers",
-                "laravel"
-            ],
-            "support": {
-                "source": "https://github.com/laravel/helpers/tree/v1.8.3"
-            },
-            "time": "2026-03-17T16:40:11+00:00"
-        },
-        {
-            "name": "laravel/legacy-factories",
-            "version": "v1.4.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laravel/legacy-factories.git",
-                "reference": "fdaadc5c7cc656503704ad87a6d5fad961cc5c8a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laravel/legacy-factories/zipball/fdaadc5c7cc656503704ad87a6d5fad961cc5c8a",
-                "reference": "fdaadc5c7cc656503704ad87a6d5fad961cc5c8a",
-                "shasum": ""
-            },
-            "require": {
-                "illuminate/macroable": "^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
-                "php": "^7.3|^8.0",
-                "symfony/finder": "^3.4|^4.0|^5.0|^6.0|^7.0"
-            },
-            "type": "library",
-            "extra": {
-                "laravel": {
-                    "providers": [
-                        "Illuminate\\Database\\Eloquent\\LegacyFactoryServiceProvider"
-                    ]
-                },
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "helpers.php"
-                ],
-                "psr-4": {
-                    "Illuminate\\Database\\Eloquent\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Taylor Otwell",
-                    "email": "taylor@laravel.com"
-                }
-            ],
-            "description": "The legacy version of the Laravel Eloquent factories.",
-            "homepage": "http://laravel.com",
-            "support": {
-                "issues": "https://github.com/laravel/framework/issues",
-                "source": "https://github.com/laravel/framework"
-            },
-            "time": "2026-02-21T13:29:40+00:00"
         },
         {
             "name": "laravel/prompts",
@@ -15803,7 +15690,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.3.0",
+        "php": "^8.5",
         "ext-bcmath": "*",
         "ext-curl": "*",
         "ext-dom": "*",

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -38,7 +38,7 @@ services:
     command: ["make", "test-coverage", "analyse", "lint"]
 
   database:
-    image: postgres:alpine
+    image: postgres:18-alpine
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust
     volumes:

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,13 +44,11 @@
                 "laravel-vite-plugin": "^3.1.3",
                 "npm-check-updates": "^23.0.1",
                 "prettier": "^3.9.6",
-                "resolve-url-loader": "^5.0.0",
                 "sass": "^1.102.0",
-                "sass-loader": "^17.x",
                 "simple-git-hooks": "^2.13.1"
             },
             "engines": {
-                "node": ">=22.x"
+                "node": ">=24.x"
             }
         },
         "node_modules/@alloc/quick-lru": {
@@ -1484,20 +1482,6 @@
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
-        "node_modules/adjust-sourcemap-loader": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/adjust-sourcemap-loader/-/adjust-sourcemap-loader-4.0.0.tgz",
-            "integrity": "sha512-OXwN5b9pCUXNQHJpwwD2qP40byEmSgzj8B4ydSN0uMNYWiFmJ6x6KwUllMmfk8Rwu/HJDFR7U8ubsWBoN0Xp0A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "loader-utils": "^2.0.0",
-                "regex-parser": "^2.2.11"
-            },
-            "engines": {
-                "node": ">=8.9"
-            }
-        },
         "node_modules/agent-base": {
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
@@ -1649,16 +1633,6 @@
             "license": "MIT",
             "engines": {
                 "node": "18 || 20 || >=22"
-            }
-        },
-        "node_modules/big.js": {
-            "version": "5.2.2",
-            "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
-            "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "*"
             }
         },
         "node_modules/binary-extensions": {
@@ -1996,13 +1970,6 @@
                 "proto-list": "~1.2.1"
             }
         },
-        "node_modules/convert-source-map": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
-            "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/core-js-pure": {
             "version": "3.50.0",
             "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.50.0.tgz",
@@ -2238,16 +2205,6 @@
             "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/emojis-list": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
-            "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 4"
-            }
         },
         "node_modules/es-define-property": {
             "version": "1.0.1",
@@ -3089,19 +3046,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/json5": {
-            "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-            "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-            "dev": true,
-            "license": "MIT",
-            "bin": {
-                "json5": "lib/cli.js"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/laravel-precognition": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/laravel-precognition/-/laravel-precognition-2.0.0.tgz",
@@ -3433,21 +3377,6 @@
             "integrity": "sha512-KCUUH9x97QWYU0SXOCGxUrZR6cSfuQrMhABB7L/0I8N0LXOeaKe7+RZs7FAwvWCV2qKfZ4Wv1luLq4OfMezSJg==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/loader-utils": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
-            "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "big.js": "^5.2.2",
-                "emojis-list": "^3.0.0",
-                "json5": "^2.1.2"
-            },
-            "engines": {
-                "node": ">=8.9.0"
-            }
         },
         "node_modules/lodash": {
             "version": "4.18.1",
@@ -4355,13 +4284,6 @@
                 "url": "https://github.com/sponsors/wooorm"
             }
         },
-        "node_modules/regex-parser": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/regex-parser/-/regex-parser-2.3.1.tgz",
-            "integrity": "sha512-yXLRqatcCuKtVHsWrNg0JL3l1zGfdXeEvDa0bdu4tCDQw0RpMDZsqbkyRTUnKMR0tXF627V2oEWjBEaEdqTwtQ==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/require-directory": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -4408,23 +4330,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/resolve-url-loader": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/resolve-url-loader/-/resolve-url-loader-5.0.0.tgz",
-            "integrity": "sha512-uZtduh8/8srhBoMx//5bwqjQ+rfYOUq8zC9NrMUGtjBiGTtFJM42s58/36+hTqeqINcnYe08Nj3LkK9lW4N8Xg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "adjust-sourcemap-loader": "^4.0.0",
-                "convert-source-map": "^1.7.0",
-                "loader-utils": "^2.0.0",
-                "postcss": "^8.2.14",
-                "source-map": "0.6.1"
-            },
-            "engines": {
-                "node": ">=12"
             }
         },
         "node_modules/reusify": {
@@ -4536,40 +4441,6 @@
                 "@parcel/watcher": "^2.4.1"
             }
         },
-        "node_modules/sass-loader": {
-            "version": "17.0.0",
-            "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-17.0.0.tgz",
-            "integrity": "sha512-0Ybm8ohBQ9LcrycVrFQp/KQBNX5a3Wda9/smS0mE/xLffzEnwvV8nykOzrbiSWNzTE3IB/jiXx8O4QmDPG2+Gw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 22.11.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/webpack"
-            },
-            "peerDependencies": {
-                "@rspack/core": "0.x || ^1.0.0 || ^2.0.0-0",
-                "sass": "^1.3.0",
-                "sass-embedded": "*",
-                "webpack": "^5.0.0"
-            },
-            "peerDependenciesMeta": {
-                "@rspack/core": {
-                    "optional": true
-                },
-                "sass": {
-                    "optional": true
-                },
-                "sass-embedded": {
-                    "optional": true
-                },
-                "webpack": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/scheduler": {
             "version": "0.27.0",
             "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -4634,16 +4505,6 @@
             "license": "MIT",
             "bin": {
                 "simple-git-hooks": "cli.js"
-            }
-        },
-        "node_modules/source-map": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/source-map-js": {

--- a/package.json
+++ b/package.json
@@ -47,12 +47,10 @@
         "laravel-vite-plugin": "^3.1.3",
         "npm-check-updates": "^23.0.1",
         "prettier": "^3.9.6",
-        "resolve-url-loader": "^5.0.0",
         "sass": "^1.102.0",
-        "sass-loader": "^17.x",
         "simple-git-hooks": "^2.13.1"
     },
     "engines": {
-        "node": ">=22.x"
+        "node": ">=24.x"
     }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -71,9 +71,7 @@
                 "vite",
                 "@vitejs/*",
                 "laravel-vite-plugin",
-                "sass",
-                "sass-loader",
-                "resolve-url-loader"
+                "sass"
             ],
             "groupName": "frontend build"
         },
@@ -150,8 +148,6 @@
                 "@vitejs/*",
                 "laravel-vite-plugin",
                 "sass",
-                "sass-loader",
-                "resolve-url-loader",
                 "@biomejs/biome",
                 "prettier",
                 "@shufo/prettier-plugin-blade",

--- a/resources/views/home/index.blade.php
+++ b/resources/views/home/index.blade.php
@@ -169,7 +169,7 @@
               </strong>
               <a href="{{ $comment->present()->getLink() }}">{{ $comment->created_at }}</a>
             </div>
-            <span>{!! MarkdownHelper::text(str_limit($comment->content, 80)) !!}</span>
+            <span>{!! MarkdownHelper::text(Str::limit($comment->content, 80)) !!}</span>
           </div>
         </div>
       @endforeach

--- a/resources/views/solution/index.blade.php
+++ b/resources/views/solution/index.blade.php
@@ -16,13 +16,13 @@
       <div class="col">
         <div class="input-group">
           <div class="input-group-text">{{ __('views.solution.index.filter.user') }}</div>
-          {{ html()->text('filter[user.name]')->value(array_get($filter, 'user.name', null))->placeholder(__('views.solution.index.filter.user'))->class('form-control') }}
+          {{ html()->text('filter[user.name]')->value(Arr::get($filter, 'user.name', null))->placeholder(__('views.solution.index.filter.user'))->class('form-control') }}
         </div>
       </div>
       <div class="col-6 col-sm-6 col-md-4 col-lg-4">
         <div class="input-group">
           <div class="input-group-text">{{ __('views.solution.index.filter.exercise') }}</div>
-          {{ html()->select('filter[exercise_id]', $exerciseTitles)->value(array_get($filter, 'exercise_id', null))->placeholder(__('views.solution.index.filter.exercise'))->class('form-control') }}
+          {{ html()->select('filter[exercise_id]', $exerciseTitles)->value(Arr::get($filter, 'exercise_id', null))->placeholder(__('views.solution.index.filter.exercise'))->class('form-control') }}
         </div>
       </div>
       <div class="col-6 col-sm-3 col-md-2 col-lg-2 d-flex justify-content-center">

--- a/tests/Feature/Http/Controllers/CommentControllerTest.php
+++ b/tests/Feature/Http/Controllers/CommentControllerTest.php
@@ -10,6 +10,7 @@ use Database\Seeders\ChaptersTableSeeder;
 use Database\Seeders\ExercisesTableSeeder;
 use Database\Seeders\UsersTableSeeder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\ControllerTestCase;
 
@@ -128,7 +129,7 @@ class CommentControllerTest extends ControllerTestCase
     {
         $routesGroup = $model->getTable();
         return route("{$routesGroup}.{$action}", [
-            str_singular($routesGroup) => $model,
+            Str::singular($routesGroup) => $model,
         ]);
     }
 


### PR DESCRIPTION
> **Stacked на #2016.** Ветка растёт из `feature/mcp-allure-testops`, поэтому в диффе временно виден и коммит `chore: add Allure TestOps MCP server` — он из #2016. После мержа #2016 здесь останется только `chore: drop unused deps and align stack versions`. Мержить после #2016.

## Pull request details

### Снятые зависимости

- npm `sass-loader` и `resolve-url-loader` — наследство webpack, в сборке не участвуют: Vite работает с `sass` напрямую. Ни одного импорта в `resources/js`, в `vite.config.js` не упоминаются. Убраны и из обеих групп в `renovate.json` («frontend build» и «Automerge: build and lint tooling»).
- composer `laravel/legacy-factories` — ни одного вызова старого `factory()`, все 7 фабрик в `database/factories` классовые.
- composer `laravel/helpers` — держался ровно на пяти вызовах, все заменены на первоисточник:
  - `str_limit` → `Str::limit` (`resources/views/home/index.blade.php`)
  - `array_get` → `Arr::get` ×2 (`resources/views/solution/index.blade.php`)
  - `str_plural` → `Str::plural` (`app/Presenters/CommentPresenter.php`)
  - `str_singular` → `Str::singular` (`tests/Feature/Http/Controllers/CommentControllerTest.php`)

Итого −4 зависимости, −369 строк (в основном lock-файлы).

### Версии стека

PHP 8.5, Node 24, образ `postgres:18-alpine` в CI, и `AGENTS.md` приведён в соответствие.

## Проверка

Замены хелперов линтер не поймал бы, поэтому проверялись рендером:

- `/ru` под авторизацией (гостю отдаётся `home.landing`, не `home.index`) — блок комментариев отрисован, `Str::limit` режет на 80 символов, ссылки `exercises/172#comment-6` и `chapters/78#comment-9` строятся через `Str::plural`.
- `/ru/solutions?filter[user.name]=fey&filter[exercise_id]=3` — оба `Arr::get` отработали: `value="fey"` в инпуте и `<option value="3" selected>`.

Плюс `make test` (1527 passed, 3776 assertions) и `make lint` (Biome + phpcs 86/86) — чисто.

`str_singular` всплыл только на прогоне тестов: `CommentControllerTest > show (chapter)` упал с `Call to undefined function str_singular()`.

## Issues fixed

Отдельного issue нет — выросло из аудита на over-engineering.

## Link to demo

Изменений в UI нет.

🤖 Generated with [Claude Code](https://claude.com/claude-code)