### PR TITLE
Drop duplicated MCP section from AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,18 +56,6 @@ Hexlet SICP — трекер изучения книги SICP: пользова�
 
 Переменная не задана — конфиг всё равно загрузится, `${ALLURE_TESTOPS_TOKEN}` уйдёт в заголовок как есть, и сервер молча не будет работать. **`claude mcp list` это не поймает: он печатает `✔ Connected` и без токена.** Проверять вызовом инструмента, например `testops_get_project`.
 
-## MCP
-
-`.mcp.json` описывает два сервера: `laravel-boost` (`php artisan boost:mcp`) и `allure-testops` (HTTP, `https://hexlet.testops.cloud/api/mcp` — тест-кейсы, тест-результаты по AQL, mute'ы).
-
-Токен Allure в git не лежит: заголовок собирается из `${ALLURE_TESTOPS_TOKEN}`. Чтобы сервер заработал у себя:
-
-1. Создать личный токен в TestOps: аватар → *Profile* → *API tokens*.
-2. Положить его в `env.ALLURE_TESTOPS_TOKEN` в `.claude/settings.local.json` (файл вне git) или в переменную окружения.
-3. Разрешить сервер при первом запуске — либо добавить `allure-testops` в `enabledMcpjsonServers` там же.
-
-Переменная не задана — конфиг всё равно загрузится, `${ALLURE_TESTOPS_TOKEN}` уйдёт в заголовок как есть, и сервер молча не будет работать. **`claude mcp list` это не поймает: он печатает `✔ Connected` и без токена.** Проверять вызовом инструмента, например `testops_get_project`.
-
 ## Architecture
 
 ### Домен (app/Models)


### PR DESCRIPTION
## Pull request details

В `AGENTS.md` секция `## MCP` лежит дважды — блоки байт-в-байт одинаковые.

Как получилось: #2017 был отведён от ветки #2016, а #2016 уехал в `main` сквошем. Из-за сквоша исходный коммит ветки перестал быть предком `main`, GitHub посчитал дифф #2017 от общего предка и переприменил строки, которые в `main` уже были. Содержимое не потерялось и не разошлось — просто продублировалось.

Удалена вторая копия, первая осталась нетронутой.

## Issues fixed

Нет issue — правка последствий мержа #2017.

## Link to demo

Только документация.

🤖 Generated with [Claude Code](https://claude.com/claude-code)